### PR TITLE
Add ServerAdapter for CherryPy >= 9

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -3255,6 +3255,25 @@ class CherryPyServer(ServerAdapter):
             server.stop()
 
 
+class CherootServer(bottle.ServerAdapter):
+    def run(self, handler):
+        from cheroot import wsgi
+        from cheroot.ssl import builtin
+        self.options['bind_addr'] = (self.host, self.port)
+        self.options['wsgi_app'] = handler
+        certfile = self.options.pop('certfile', None)
+        keyfile = self.options.pop('keyfile', None)
+        chainfile = self.options.pop('chainfile', None)
+        server = wsgi.Server(**self.options)
+        if certfile and keyfile:
+            server.ssl_adapter = builtin.BuiltinSSLAdapter(
+                    certfile, keyfile, chainfile)
+        try:
+            server.start()
+        finally:
+            server.stop()
+
+
 class WaitressServer(ServerAdapter):
     def run(self, handler):
         from waitress import serve


### PR DESCRIPTION
Since CherryPy >= 9, the server part of CherryPy has been extracted and named Cheroot. Thus the old CherryPy ServerAdapter does not work for CherryPy >= 9: the import fails, and the SSL part should be different too. Cheroot can be installed (git install cheroot) without CherryPy so that we can just have a CherootServer adapter in addition to the CherryPyServer adapter for the older versions.